### PR TITLE
Update typo in preferences.json

### DIFF
--- a/TransparentZen/preferences.json
+++ b/TransparentZen/preferences.json
@@ -14,7 +14,7 @@
   },
   {
     "property": "zen.view.grey-out-inactive-windows",
-    "label": "👀 Keep transparency when not in focus on linux",
+    "label": "👀 Disable transparency when not in focus on linux",
     "type": "checkbox",
     "defaultValue": false,
     "disabledOn": ["windows", "macos"]


### PR DESCRIPTION
Correct the inverted option in the preferences menu. Fixes https://github.com/sameerasw/zen-themes/issues/31.